### PR TITLE
Req 4 pipeline state

### DIFF
--- a/source/common/material/pipeline-state.hpp
+++ b/source/common/material/pipeline-state.hpp
@@ -66,6 +66,15 @@ namespace our {
             // regardless of the drawing operation attempted. 
             glColorMask(colorMask.r, colorMask.g, colorMask.b, colorMask.a);
 
+            if (blending.enabled) glEnable(GL_BLEND); else glDisable(GL_BLEND);
+            // Configure blending options
+            // Configure blending equation (GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX)
+            glBlendEquation(blending.equation);
+            // Configure blending function (GL_ZERO, GL_ONE, GL_SRC_COLOR, GL_ONE_MINUS_SRC_COLOR, GL_DST_COLOR, GL_ONE_MINUS_DST_COLOR, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_CONSTANT_COLOR, GL_ONE_MINUS_CONSTANT_COLOR, GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA, GL_SRC_ALPHA_SATURATE, GL_SRC1_COLOR, GL_ONE_MINUS_SRC1_COLOR, GL_SRC1_ALPHA, GL_ONE_MINUS_SRC1_ALPHA)
+            glBlendFunc(blending.sourceFactor, blending.destinationFactor);
+            // Configure blending constant color
+            glBlendColor(blending.constantColor.r, blending.constantColor.g, blending.constantColor.b, blending.constantColor.a);
+
         }
 
         // Given a json object, this function deserializes a PipelineState structure


### PR DESCRIPTION
# Requirement 4 - Pipeline State

OpenGL is a state machine where the options we pick are stored in the OpenGL context and affect the upcoming draw calls. Since each object may require different options while drawing (e.g. transparent objects require blending while Opaque objects don't), we would need to store the options for each object in a data structure and set the OpenGL options to match the given options before drawing.

This is where we use the "PipelineState" structure which we will use to store the depth testing, face culling, blending and color/depth mask options. The setup function of the PipelineState sets the OpenGL options to match the ones stored in the corresponding PipelineState instance.

## Tests Passed
```
Matches: 14/14
SUCCESS: All outputs are correct

Overall Results
SUCCESS: All outputs are correct
```
